### PR TITLE
feat: Add standard run scripts for React Native

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "A React Native application with Firebase Authentication.",
   "main": "index.js",
   "scripts": {
+    "start": "react-native start",
+    "android": "react-native run-android",
+    "ios": "react-native run-ios",
     "test": "echo \"Error: no test specified\" && exit 1",
     "type-check": "./node_modules/.bin/tsc --noEmit"
   },


### PR DESCRIPTION
Adds the standard `start`, `android`, and `ios` scripts to package.json to simplify the process of running the application.

This helps address the user's issue where they were unable to see the project's design, as it provides the necessary commands to build and launch the React Native application.